### PR TITLE
Allow specifying an array or string for mount

### DIFF
--- a/archive/archive.go
+++ b/archive/archive.go
@@ -9,7 +9,7 @@ import (
 // Archive is an interface for packing and unpacking archive formats.
 type Archive interface {
 	// Pack writes an archive containing the source
-	Pack(src string, w io.Writer) error
+	Pack(srcs []string, w io.Writer) error
 
 	// Unpack reads the archive and restores it to the destination
 	Unpack(dst string, r io.Reader) error

--- a/archive/tar.go
+++ b/archive/tar.go
@@ -20,55 +20,66 @@ func NewTarArchive() Archive {
 	return &tarArchive{}
 }
 
-func (a *tarArchive) Pack(src string, w io.Writer) error {
-	// ensure the src actually exists before trying to tar it
-	if _, err := os.Stat(src); err != nil {
-		return err
-	}
-
+func (a *tarArchive) Pack(srcs []string, w io.Writer) error {
 	tw := tar.NewWriter(w)
 	defer tw.Close()
 
-	// walk path
-	return filepath.Walk(src, func(path string, fi os.FileInfo, err error) error {
-		if err != nil {
+	// Loop through each source
+	var fwErr error
+	for _, s := range srcs {
+		// ensure the src actually exists before trying to tar it
+		if _, err := os.Stat(s); err != nil {
 			return err
 		}
 
-		var link string
-		if fi.Mode()&os.ModeSymlink == os.ModeSymlink {
-			if link, err = os.Readlink(path); err != nil {
+		// walk path
+		fwErr = filepath.Walk(s, func(path string, fi os.FileInfo, err error) error {
+			if err != nil {
 				return err
 			}
-			log.Infof("Symbolic link found at %s", link)
-		}
 
-		header, err := tar.FileInfoHeader(fi, fi.Name())
-		if err != nil {
+			var link string
+			if fi.Mode()&os.ModeSymlink == os.ModeSymlink {
+				if link, err = os.Readlink(path); err != nil {
+					return err
+				}
+				log.Infof("Symbolic link found at %s", link)
+			}
+
+			header, err := tar.FileInfoHeader(fi, fi.Name())
+			if err != nil {
+				return err
+			}
+
+			header.Name = strings.TrimPrefix(filepath.ToSlash(path), "/")
+
+			if err = tw.WriteHeader(header); err != nil {
+				return err
+			}
+
+			if !fi.Mode().IsRegular() {
+				log.Debugf("Directory found at %s", path)
+				return nil
+			}
+
+			log.Debugf("File found at %s", path)
+
+			file, err := os.Open(path)
+			if err != nil {
+				return err
+			}
+
+			defer file.Close()
+			_, err = io.Copy(tw, file)
 			return err
+		})
+
+		if fwErr != nil {
+			return fwErr
 		}
+	}
 
-		header.Name = strings.TrimPrefix(filepath.ToSlash(path), "/")
-
-		if err = tw.WriteHeader(header); err != nil {
-			return err
-		}
-
-		if !fi.Mode().IsRegular() {
-			log.Debugf("Directory found at %s", path)
-			return nil
-		}
-
-		log.Debugf("File found at %s", path)
-
-		file, err := os.Open(path)
-		if err != nil {
-			return err
-		}
-		defer file.Close()
-		_, err = io.Copy(tw, file)
-		return err
-	})
+	return fwErr
 }
 
 func (a *tarArchive) Unpack(dst string, r io.Reader) error {

--- a/plugin/cli.go
+++ b/plugin/cli.go
@@ -3,6 +3,7 @@ package plugin
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/urfave/cli"
@@ -34,7 +35,7 @@ func PluginFlags() []cli.Flag {
 			Usage:  "path",
 			EnvVar: "PLUGIN_PATH",
 		},
-		cli.StringFlag{
+		cli.StringSliceFlag{
 			Name:   "mount",
 			Usage:  "cache directories",
 			EnvVar: "PLUGIN_MOUNT",
@@ -93,11 +94,11 @@ func newPlugin(c *cli.Context) (*plugin, error) {
 	}
 
 	var mode string
-	var mount string
+	var mount []string
 
 	if rebuild {
 		// Look for the mount points to rebuild
-		mount = c.GlobalString(mountFlag)
+		mount = c.GlobalStringSlice(mountFlag)
 
 		if len(mount) == 0 {
 			return nil, errors.New("No mounts specified")
@@ -106,7 +107,6 @@ func newPlugin(c *cli.Context) (*plugin, error) {
 		mode = rebuildMode
 	} else {
 		mode = restoreMode
-		mount = ""
 	}
 
 	// Get the path to place the cache files

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -53,5 +53,5 @@ type plugin struct {
 	Filename string
 	Path     string
 	Mode     string
-	Mount    string
+	Mount    []string
 }


### PR DESCRIPTION
* Set `plugin.Mount` from `string` to `[]string`
* Converted functions using the mount as a `src` to take `[]string` instead of `string`
* In tar.go loop through the `srcs` and call `filepath.Walk` for each element

Also includes minor update to `make(chan error)` to be `make(chan error, 1)` to prevent hanging when Get/Put functions return an error.